### PR TITLE
Fix slowapi import error in main.py

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -9,9 +9,9 @@ from sqlalchemy.exc import SQLAlchemyError
 from datetime import datetime
 
 # Issue #18: Import rate limiting
-from slowapi import Limiter, _rate_limit_exceeded_handler
+from slowapi import Limiter
 from slowapi.util import get_remote_address
-from slowapi.errors import RateLimitExceeded
+from slowapi.errors import RateLimitExceeded, _rate_limit_exceeded_handler
 from slowapi.middleware import SlowAPIMiddleware
 
 from app.api import tasks, auth, ai_assistant, projects, tags, templates  # Issue #23: Add templates


### PR DESCRIPTION
## Fix for ModuleNotFoundError: No module named 'slowapi'

### Problem
The application was failing to start with a `ModuleNotFoundError` because the `_rate_limit_exceeded_handler` was being imported from the wrong module.

### Solution
Fixed the import statement in `backend/main.py`:
- Changed from: `from slowapi import Limiter, _rate_limit_exceeded_handler`
- Changed to: `from slowapi.errors import RateLimitExceeded, _rate_limit_exceeded_handler`

The `_rate_limit_exceeded_handler` should be imported from `slowapi.errors`, not from the main `slowapi` module.

### Additional Notes
- The `slowapi` package is already listed in `requirements.txt`
- If you're still seeing the error after this fix, make sure to install dependencies: `pip install -r requirements.txt`

### Testing
After merging this PR, the application should start successfully with:
```bash
uvicorn main:app --reload
```