### PR TITLE
Fix missing model imports - Project and Tag are in task.py

### DIFF
--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -1,7 +1,5 @@
 from .user import User
-from .task import Task
-from .project import Project
-from .tag import Tag
+from .task import Task, Project, Tag
 from .template import TaskTemplate  # Issue #23
 
 __all__ = ['User', 'Task', 'Project', 'Tag', 'TaskTemplate']


### PR DESCRIPTION
## Fix for ModuleNotFoundError: No module named 'app.models.project'

### Problem
After fixing the slowapi import error, a new error appeared:
```
ModuleNotFoundError: No module named 'app.models.project'
```

The `app/models/__init__.py` file was trying to import `Project` and `Tag` from separate files that don't exist.

### Root Cause
The `Project` and `Tag` models are actually defined in the `task.py` file, not in separate `project.py` and `tag.py` files.

### Solution
Updated the `app/models/__init__.py` file to import `Project` and `Tag` from the `task` module where they are actually defined:

```python
# Before:
from .project import Project
from .tag import Tag

# After:
from .task import Task, Project, Tag
```

### Testing
After merging both PR #37 (slowapi fix) and this PR, the application should start successfully with:
```bash
uvicorn main:app --reload
```